### PR TITLE
Fix imports for 3_1chat_LLM

### DIFF
--- a/3_1chat_LLM.py
+++ b/3_1chat_LLM.py
@@ -2,6 +2,10 @@
 # 呼叫Openai GPT4o LLM
 
 from openai import OpenAI
+import os
+import chromadb
+import chromadb.utils.embedding_functions as embedding_functions
+import pprint
 
 # 要準備自己的system prompt, user_prompt
 GPT_MODEL = "gpt-4o" # "gpt-4-turbo-2024-04-09"or "gpt-3.5-turbo-1106" or "gpt-4o"
@@ -86,7 +90,12 @@ def get_chat_response(query, report, seed: int = None):
 
 #testing
 query="糖尿病前期"
-with open("patient_c.txt",'r') as f:
-    p_testing_report = f.read()
+try:
+    with open("patient_c.txt", "r") as f:
+        p_testing_report = f.read()
+except FileNotFoundError:
+    print("patient_c.txt not found, using empty report")
+    p_testing_report = ""
 
 p_c = get_chat_response(query, p_testing_report)
+print(p_c)


### PR DESCRIPTION
## Summary
- add missing imports for OS, chromadb and pprint in `3_1chat_LLM.py`
- handle missing `patient_c.txt` when the script is run for testing

## Testing
- `python3 - <<'PY'
import sys, types, runpy
class DummyEF: pass
class DummyOpenAI:
    def __init__(self, *a, **kw): pass
    class chat:
        class completions:
            @staticmethod
            def create(**kwargs):
                class DC: pass
                DC.message = types.SimpleNamespace(content='dummy')
                c = types.SimpleNamespace(choices=[DC], system_fingerprint='dummy', usage=types.SimpleNamespace(prompt_tokens=0,total_tokens=0))
                return c
sys.modules['openai']=types.SimpleNamespace(OpenAI=DummyOpenAI)
class DC:
    def query(self, *a, **kw): return {'documents': [['doc1','doc2']]}
class DP:
    def __init__(self, path): pass
    def get_collection(self, *a, **kw): return DC()
embedding = types.SimpleNamespace(OpenAIEmbeddingFunction=lambda *a, **kw: DummyEF())
chromadb = types.SimpleNamespace(PersistentClient=DP, utils=types.SimpleNamespace(embedding_functions=embedding))
sys.modules['chromadb']=chromadb
sys.modules['chromadb.utils']=chromadb.utils
sys.modules['chromadb.utils.embedding_functions']=embedding
runpy.run_path('3_1chat_LLM.py')
PY

------
https://chatgpt.com/codex/tasks/task_e_687ab8a658bc8330b9ecf30ee2d6cfc3