### PR TITLE
Update embedding script to load docs automatically

### DIFF
--- a/2_1embed_store_query.py
+++ b/2_1embed_store_query.py
@@ -1,9 +1,40 @@
-# 接續 1_load_split.py
-# 獲得embdding, 建自己的DB,向量資料、chunking資料傳入db, 即可檢索，若要再次使用該向量資料庫，就不用再傳入一次資料，參考2_2getvector_query.py
+"""Create a local Chroma vector store and query it.
+
+This script can be run directly.  It dynamically loads the splitting logic
+from ``1_load_split.py`` so that the markdown file will be read and split into
+``advise_docs_list`` automatically.  The resulting documents are embedded and
+stored in a Chroma database.
+
+Once the embeddings are stored they can be queried again without reloading the
+data (see ``2_2getvector_query.py``).
+"""
 
 import os
+import importlib.util
 import chromadb
 import chromadb.utils.embedding_functions as embedding_functions
+
+
+def load_advise_docs():
+    """Load and split the markdown instructions.
+
+    The logic is imported from ``1_load_split.py`` so we don't duplicate the
+    splitting implementation here.
+    """
+    module_path = os.path.join(os.path.dirname(__file__), "1_load_split.py")
+    spec = importlib.util.spec_from_file_location("load_split", module_path)
+    load_split = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(load_split)
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    file_path = os.path.join(script_dir, "data", "med_instruction_v2.md")
+    with open(file_path, "r", encoding="utf-8") as f:
+        md_content = f.read()
+
+    return load_split.read_split_md(md_content)
+
+
+advise_docs_list = load_advise_docs()
 
 # 1. 用chromadb用openai api, 請先輸入自己的openai_api_key
 openai_ef_chroma = embedding_functions.OpenAIEmbeddingFunction(
@@ -28,7 +59,8 @@ ids = []
 
 # 遍歷 Document 對象列表，提取所需信息
 for index, doc in enumerate(advise_docs_list):
-    documents.append(doc.get_content)
+    # ``Document`` objects expose their text via ``page_content``
+    documents.append(doc.page_content)
     metadatas.append(doc.metadata)
     ids.append(f"id{index + 1}")
 


### PR DESCRIPTION
## Summary
- dynamically load the Markdown splitting function from `1_load_split.py`
- use `page_content` to access text from `Document` objects
- clarify workflow in a new module docstring

## Testing
- `python -m py_compile 2_1embed_store_query.py`

------
https://chatgpt.com/codex/tasks/task_e_687abbb2ede08330909429c562d9b729