### PR TITLE
Add simple text split & vector retrieval workflow with tests

### DIFF
--- a/data/sample.md
+++ b/data/sample.md
@@ -1,0 +1,8 @@
+# Diabetes Management
+General guidelines for diabetes.
+## Diet
+Follow a balanced diet.
+## Exercise
+Regular exercise helps.
+# Hypertension
+Tips for hypertension management.

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,0 +1,11 @@
+from text_utils import read_split_md, Document
+
+
+def test_read_split_md_basic():
+    md = "# Header1\nText1\n## Subheader\nText2"
+    docs = read_split_md(md)
+    assert len(docs) == 2
+    assert docs[0].metadata["header"] == "Header1"
+    assert docs[0].page_content == "Text1"
+    assert docs[1].metadata["header"] == "Subheader"
+    assert docs[1].page_content == "Text2"

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,0 +1,15 @@
+from text_utils import Document
+from vector_store import VectorIndex
+
+
+def test_query_index_returns_relevant_doc():
+    docs = [
+        Document("apple orange", {}),
+        Document("banana pear", {}),
+        Document("apple pie recipe", {}),
+    ]
+    index = VectorIndex(docs)
+    results = index.query("apple", k=2)
+    assert len(results) == 2
+    assert results[0].page_content in {"apple orange", "apple pie recipe"}
+    assert results[0].page_content != "banana pear"

--- a/text_utils.py
+++ b/text_utils.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+import re
+from typing import List, Dict
+
+@dataclass
+class Document:
+    page_content: str
+    metadata: Dict[str, str]
+
+def read_split_md(md_doc: str) -> List[Document]:
+    """Split markdown text into Document objects by headers."""
+    docs: List[Document] = []
+    lines = md_doc.splitlines()
+    current_lines = []
+    current_meta = {"header": "", "level": 0}
+    header_re = re.compile(r"^(#+)\s*(.*)")
+
+    for line in lines:
+        match = header_re.match(line)
+        if match:
+            if current_lines:
+                docs.append(Document(page_content="\n".join(current_lines).strip(), metadata=current_meta))
+            level = len(match.group(1))
+            header = match.group(2).strip()
+            current_meta = {"header": header, "level": level}
+            current_lines = []
+        else:
+            current_lines.append(line)
+    if current_lines:
+        docs.append(Document(page_content="\n".join(current_lines).strip(), metadata=current_meta))
+    return docs

--- a/vector_store.py
+++ b/vector_store.py
@@ -1,0 +1,50 @@
+from typing import List, Dict
+from math import sqrt
+from collections import defaultdict
+from text_utils import Document
+
+class VectorIndex:
+    def __init__(self, documents: List[Document]):
+        self.documents = documents
+        self.vocab: Dict[str, int] = {}
+        self.vectors: List[List[int]] = []
+        self._build_index()
+
+    def _tokenize(self, text: str) -> List[str]:
+        return [t.lower() for t in text.split()]
+
+    def _build_index(self) -> None:
+        # Build vocabulary
+        for doc in self.documents:
+            for token in self._tokenize(doc.page_content):
+                if token not in self.vocab:
+                    self.vocab[token] = len(self.vocab)
+        # Create vectors
+        for doc in self.documents:
+            vec = [0] * len(self.vocab)
+            for token in self._tokenize(doc.page_content):
+                if token in self.vocab:
+                    vec[self.vocab[token]] += 1
+            self.vectors.append(vec)
+
+    def _vectorize_query(self, query: str) -> List[int]:
+        vec = [0] * len(self.vocab)
+        for token in self._tokenize(query):
+            if token in self.vocab:
+                vec[self.vocab[token]] += 1
+        return vec
+
+    @staticmethod
+    def _cosine(a: List[int], b: List[int]) -> float:
+        dot = sum(x*y for x, y in zip(a, b))
+        norm_a = sqrt(sum(x*x for x in a))
+        norm_b = sqrt(sum(x*x for x in b))
+        if norm_a == 0 or norm_b == 0:
+            return 0.0
+        return dot / (norm_a * norm_b)
+
+    def query(self, text: str, k: int = 1) -> List[Document]:
+        q_vec = self._vectorize_query(text)
+        sims = [self._cosine(vec, q_vec) for vec in self.vectors]
+        ranked = sorted(zip(sims, self.documents), key=lambda x: x[0], reverse=True)
+        return [doc for _sim, doc in ranked[:k]]

--- a/workflow.py
+++ b/workflow.py
@@ -1,0 +1,23 @@
+"""Simple end-to-end workflow for demonstration."""
+import os
+from text_utils import read_split_md
+from vector_store import VectorIndex
+
+
+def main():
+    script_dir = os.path.dirname(__file__)
+    md_path = os.path.join(script_dir, "data", "sample.md")
+    with open(md_path, "r", encoding="utf-8") as f:
+        md_content = f.read()
+
+    docs = read_split_md(md_content)
+    index = VectorIndex(docs)
+
+    query = "diet"
+    results = index.query(query, k=2)
+    answer = "\n".join(doc.page_content for doc in results)
+    print("Response:\n" + answer)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `read_split_md` and `VectorIndex` utilities
- add entry-point `workflow.py` showing load→embed→query steps
- provide sample markdown data
- add pytest unit tests for splitting and retrieval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687adeecac648330863f3c4f2ed066e5