### PR TITLE
Add config imports to chat scripts

### DIFF
--- a/3_1chat_LLM.py
+++ b/3_1chat_LLM.py
@@ -1,6 +1,7 @@
 # 接續2_2getvector_query.py
 # 呼叫Openai GPT4o LLM
 
+import config
 from openai import OpenAI
 import os
 import chromadb

--- a/3_2chat_LLM_local.py
+++ b/3_2chat_LLM_local.py
@@ -1,5 +1,6 @@
 # 接續2_getvector_query.py
 # 呼叫local LLM
+import config
 import requests
 import chromadb
 import chromadb.utils.embedding_functions as embedding_functions


### PR DESCRIPTION
## Summary
- import the shared config module in 3_1chat_LLM.py so it can access configured paths
- do the same for 3_2chat_LLM_local.py to reference configuration constants

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69006c81682883309c29dd67c3abf024