### PR TITLE
Configure HuggingFace API key handling

### DIFF
--- a/2_1embed_store_query.py
+++ b/2_1embed_store_query.py
@@ -43,9 +43,16 @@ openai_ef_chroma = embedding_functions.OpenAIEmbeddingFunction(
                 model_name="text-embedding-3-small")
 
 # 2. 用chromadb用huggingface embedding, 中文用這個不會亂碼, HF api_key自己申請
-import chromadb.utils.embedding_functions as embedding_functions
+try:
+    huggingface_api_key = config.get_huggingface_api_key()
+except RuntimeError as err:
+    raise RuntimeError(
+        "Unable to initialise the HuggingFace embedding function. "
+        f"{err}"
+    ) from err
+
 huggingface_ef = embedding_functions.HuggingFaceEmbeddingFunction(
-    api_key="XXXX",
+    api_key=huggingface_api_key,
     model_name="intfloat/multilingual-e5-large-instruct"
 )
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ pip install -r requirements.txt
 
 3. Configure environment variables:
    - `OPENAI_API_KEY` – API key for OpenAI models.
+   - `HUGGINGFACE_API_KEY` – API key for HuggingFace embeddings used in `2_1embed_store_query.py` and `rag_example.py`.
+     You can also assign `HUGGINGFACE_API_KEY` directly inside `config.py` if you prefer to keep credentials out of your shell.
    - `genmini_api_key` – API key for Google Gemini models.
    - Optional: `MLFLOW_TRACKING_URI` to enable [MLflow](https://mlflow.org/) experiment tracking.
 

--- a/config.py
+++ b/config.py
@@ -1,5 +1,8 @@
 import os
 
+# Environment variable names
+HUGGINGFACE_API_KEY_ENV_VAR = "HUGGINGFACE_API_KEY"
+
 # Base directory of the repository
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -13,3 +16,33 @@ PATIENT_FILE = os.path.join(BASE_DIR, "patient_c.txt")
 
 # Default model for local LLM examples
 DEFAULT_LOCAL_MODEL = "yabi/breeze-7b-instruct-v1_0_q6_k:latest"
+
+
+def get_env_variable(name: str) -> str:
+    """Return the value of an environment variable or raise a helpful error."""
+
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(
+            f"Environment variable '{name}' is not set. "
+            "Please export it in your shell or add it to your .env file."
+        )
+    return value
+
+
+def get_huggingface_api_key() -> str:
+    """Return the configured HuggingFace API key."""
+
+    key = os.getenv(HUGGINGFACE_API_KEY_ENV_VAR)
+    if key:
+        return key
+
+    # Allow advanced users to set the key directly in config.py if desired.
+    key = globals().get("HUGGINGFACE_API_KEY")
+    if key:
+        return key
+
+    raise RuntimeError(
+        "HuggingFace API key is not configured. Set the environment variable "
+        f"'{HUGGINGFACE_API_KEY_ENV_VAR}' or assign 'HUGGINGFACE_API_KEY' in config.py."
+    )

--- a/rag_example.py
+++ b/rag_example.py
@@ -29,8 +29,16 @@ text_splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=100
 ])
 
 # 3.embdding(HF)
+try:
+    huggingface_api_key = config.get_huggingface_api_key()
+except RuntimeError as err:
+    raise RuntimeError(
+        "Unable to initialise the HuggingFace embedding function for rag_example.py. "
+        f"{err}"
+    ) from err
+
 huggingface_ef = embedding_functions.HuggingFaceEmbeddingFunction(
-    api_key="XXXXX",
+    api_key=huggingface_api_key,
     model_name="intfloat/multilingual-e5-large-instruct"
 )
 


### PR DESCRIPTION
## Summary
- declare the `HUGGINGFACE_API_KEY` environment variable name in `config.py`
- expose helpers to retrieve the HuggingFace key and reuse them in the embedding scripts with clear error messages
- document how to configure the HuggingFace key in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6900704ace708330a1829f404a69ecaf