### PR TITLE
Standardize Gemini API key environment variable

### DIFF
--- a/3_3chat_LLM_gemini.py
+++ b/3_3chat_LLM_gemini.py
@@ -4,7 +4,14 @@ import time
 import mlflow
 from mlops.mlflow_utils import start_run, log_metrics
 
-genai.configure(api_key=os.environ.get("genmini_api_key"))
+API_KEY_ENV_VAR = "GEMINI_API_KEY"
+api_key = os.environ.get(API_KEY_ENV_VAR)
+if not api_key:
+    raise EnvironmentError(
+        f"Missing Google Gemini API key. Please set the '{API_KEY_ENV_VAR}' environment variable."
+    )
+
+genai.configure(api_key=api_key)
 
 # Set up the model
 generation_config = {

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pip install -r requirements.txt
 
 3. Configure environment variables:
    - `OPENAI_API_KEY` – API key for OpenAI models.
-   - `genmini_api_key` – API key for Google Gemini models.
+   - `GEMINI_API_KEY` – API key for Google Gemini models.
    - Optional: `MLFLOW_TRACKING_URI` to enable [MLflow](https://mlflow.org/) experiment tracking.
 
    Environment variables can be exported in your shell or saved in a `.env` file and loaded with your preferred tool.
@@ -86,7 +86,7 @@ Calls a running Ollama server at `http://localhost:11434/api/chat` using the sto
 ```bash
 python 3_3chat_LLM_gemini.py
 ```
-Example using the Gemini API. Set `genmini_api_key` before running.
+Example using the Gemini API. Set `GEMINI_API_KEY` before running.
 
 ### 7. RAG over PDF
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -15,7 +15,7 @@
    - `patient_c.txt` – 可選的病歷報告文件，供聊天示例使用。
 3. 配置環境變量：
    - `OPENAI_API_KEY` – OpenAI 模型的 API key。
-   - `genmini_api_key` – Google Gemini 模型的 API key。
+   - `GEMINI_API_KEY` – Google Gemini 模型的 API key。
    - 可選：`MLFLOW_TRACKING_URI` 用於啟用 [MLflow](https://mlflow.org/) 實驗記錄。
 
    環境變量可以直接導出到 shell，或保存在 `.env` 文件中再加載。
@@ -58,7 +58,7 @@ python 3_2chat_LLM_local.py
 ```bash
 python 3_3chat_LLM_gemini.py
 ```
-示例使用 Gemini API。運行前請設置 `genmini_api_key`。
+示例使用 Gemini API。運行前請設置 `GEMINI_API_KEY`。
 
 ### 7. PDF RAG 示例
 ```bash


### PR DESCRIPTION
## Summary
- switch the Gemini client configuration to read the GEMINI_API_KEY environment variable
- add a clear error message when the Gemini API key is missing
- update the English and Chinese README instructions to reference GEMINI_API_KEY

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6900719568a483308f8bf09d892a1f49