### PR TITLE
Implement ingestion, embedding, and retraining pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+.env
+.venv
+
+# Pipeline outputs
+/data/processed_docs.jsonl
+/embeddings/
+/models/

--- a/docs/example.txt
+++ b/docs/example.txt
@@ -1,0 +1,3 @@
+This is a placeholder document used to exercise the automated pipeline.
+It contains a couple of lines of text so the ingestion and embedding
+stages have content to operate on.

--- a/mlops/dvc.yaml
+++ b/mlops/dvc.yaml
@@ -1,0 +1,22 @@
+stages:
+  ingest:
+    cmd: python -m pipelines.ingest --input-dir docs --output-path data/processed_docs.jsonl
+    deps:
+      - docs
+      - pipelines/ingest.py
+    outs:
+      - data/processed_docs.jsonl
+  embed:
+    cmd: python -m pipelines.embed --input-path data/processed_docs.jsonl --output-path embeddings/embeddings.jsonl
+    deps:
+      - data/processed_docs.jsonl
+      - pipelines/embed.py
+    outs:
+      - embeddings/embeddings.jsonl
+  retrain:
+    cmd: python -m pipelines.retrain --skip-ingest --skip-embed --processed-path data/processed_docs.jsonl --embeddings-path embeddings/embeddings.jsonl --model-path models/model.json
+    deps:
+      - embeddings/embeddings.jsonl
+      - pipelines/retrain.py
+    outs:
+      - models/model.json

--- a/pipelines/embed.py
+++ b/pipelines/embed.py
@@ -1,0 +1,189 @@
+"""Embedding pipeline that converts processed documents into vector form."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import math
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Sequence
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_EMBED_DIM = 16
+
+
+class EmbeddingStore:
+    """A small helper that reads and writes embedding JSONL files."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._store: Dict[str, Dict[str, object]] = {}
+        if path.exists():
+            self._store = {
+                record["id"]: record
+                for record in self._iter_records()
+            }
+
+    def _iter_records(self) -> Iterator[Dict[str, object]]:
+        with self.path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                if not line.strip():
+                    continue
+                yield json.loads(line)
+
+    def get(self, doc_id: str) -> Dict[str, object] | None:
+        return self._store.get(doc_id)
+
+    def update(self, doc_id: str, record: Dict[str, object]) -> None:
+        self._store[doc_id] = record
+
+    def delete(self, doc_id: str) -> None:
+        self._store.pop(doc_id, None)
+
+    def persist(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("w", encoding="utf-8") as fh:
+            for record in self._store.values():
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    def records(self) -> Iterable[Dict[str, object]]:
+        return self._store.values()
+
+
+def _load_processed_docs(path: Path) -> List[Dict[str, str]]:
+    if not path.exists():
+        raise FileNotFoundError(f"Processed documents not found at {path}")
+
+    docs: List[Dict[str, str]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            data = json.loads(line)
+            docs.append(data)
+    return docs
+
+
+def _hash_to_unit_interval(text: str) -> List[float]:
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    vector = []
+    for i in range(0, len(digest), 2):
+        value = int.from_bytes(digest[i : i + 2], byteorder="little")
+        vector.append(value / 65535.0)
+    return vector
+
+
+def embed_text(text: str, dim: int = DEFAULT_EMBED_DIM) -> List[float]:
+    """Generate a deterministic pseudo-embedding for the given text."""
+
+    base_vector = _hash_to_unit_interval(text)
+    if len(base_vector) < dim:
+        repeats = math.ceil(dim / len(base_vector))
+        base_vector = (base_vector * repeats)[:dim]
+    return base_vector[:dim]
+
+
+def embed_documents(
+    processed_docs_path: Path,
+    embeddings_path: Path,
+    *,
+    dim: int = DEFAULT_EMBED_DIM,
+    recompute: bool = False,
+) -> Dict[str, Dict[str, object]]:
+    """Embed processed documents and write them to disk.
+
+    Args:
+        processed_docs_path: Location of the JSONL file produced by ingestion.
+        embeddings_path: Output location for the embedding store.
+        dim: Dimensionality of the generated embeddings.
+        recompute: If ``True`` all embeddings are regenerated from scratch.
+    """
+
+    docs = _load_processed_docs(processed_docs_path)
+    store = EmbeddingStore(embeddings_path)
+
+    if recompute:
+        store = EmbeddingStore(embeddings_path)
+        store._store.clear()
+
+    updated = 0
+    for doc in docs:
+        doc_id = doc["id"]
+        checksum = doc["checksum"]
+        existing = store.get(doc_id)
+        if existing and existing.get("checksum") == checksum and not recompute:
+            logger.debug("Skipping %s (unchanged)", doc_id)
+            continue
+
+        embedding = embed_text(doc["text"], dim=dim)
+        record = {
+            "id": doc_id,
+            "checksum": checksum,
+            "embedding": embedding,
+        }
+        store.update(doc_id, record)
+        updated += 1
+
+    # Drop embeddings for documents that were removed
+    doc_ids = {doc["id"] for doc in docs}
+    for existing_id in list(store._store.keys()):
+        if existing_id not in doc_ids:
+            store.delete(existing_id)
+
+    store.persist()
+    logger.info("Updated %s embeddings (total %s)", updated, len(store._store))
+    return {rec["id"]: rec for rec in store.records()}
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate embeddings")
+    parser.add_argument(
+        "--input-path",
+        type=Path,
+        default=Path("data/processed_docs.jsonl"),
+        help="Path to the processed documents JSONL",
+    )
+    parser.add_argument(
+        "--output-path",
+        type=Path,
+        default=Path("embeddings/embeddings.jsonl"),
+        help="Where to store the embeddings",
+    )
+    parser.add_argument(
+        "--dim",
+        type=int,
+        default=DEFAULT_EMBED_DIM,
+        help="Embedding dimensionality",
+    )
+    parser.add_argument(
+        "--recompute",
+        action="store_true",
+        help="Force regeneration of all embeddings",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    args = parse_args(argv or sys.argv[1:])
+
+    try:
+        embed_documents(
+            args.input_path,
+            args.output_path,
+            dim=args.dim,
+            recompute=args.recompute,
+        )
+    except Exception as exc:
+        logger.error("Embedding failed: %s", exc)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipelines/ingest.py
+++ b/pipelines/ingest.py
@@ -1,0 +1,150 @@
+"""Utilities for ingesting and cleaning raw documents.
+
+This module scans an input directory for supported document types, extracts
+plain text, applies lightweight normalisation and writes the cleaned result to
+``data/``.  The output is a JSON Lines file where each line contains a document
+identifier, source path, checksum and cleaned text.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, List, Sequence
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_SUFFIXES = {".txt", ".md", ".markdown", ".rst", ".text", ".json"}
+PDF_SUFFIXES = {".pdf"}
+
+
+@dataclass
+class Document:
+    """Represents a cleaned document ready for downstream processing."""
+
+    identifier: str
+    source: Path
+    text: str
+
+    @property
+    def checksum(self) -> str:
+        return hashlib.sha256(self.text.encode("utf-8")).hexdigest()
+
+
+def _clean_text(text: str) -> str:
+    """Remove spurious whitespace and normalise newlines."""
+
+    stripped = text.replace("\r\n", "\n").replace("\r", "\n")
+    lines = [line.strip() for line in stripped.splitlines()]
+    lines = [line for line in lines if line]
+    return "\n".join(lines)
+
+
+def _read_text_file(path: Path) -> str:
+    if path.suffix.lower() == ".json":
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return _clean_text("\n".join(str(v) for v in data.values()))
+        if isinstance(data, list):
+            return _clean_text("\n".join(str(v) for v in data))
+        return _clean_text(str(data))
+
+    return _clean_text(path.read_text(encoding="utf-8"))
+
+
+def _read_pdf_file(path: Path) -> str:
+    try:
+        import fitz  # type: ignore
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError(
+            "PyMuPDF (fitz) is required to process PDF files. Install it via "
+            "`pip install PyMuPDF` or remove PDF files from the docs directory."
+        ) from exc
+
+    with fitz.open(path) as doc:
+        text_chunks: List[str] = []
+        for page in doc:
+            text_chunks.append(page.get_text())
+    return _clean_text("\n".join(text_chunks))
+
+
+def _iter_documents(input_dir: Path) -> Iterator[Document]:
+    for path in sorted(input_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        suffix = path.suffix.lower()
+        try:
+            if suffix in SUPPORTED_SUFFIXES:
+                text = _read_text_file(path)
+            elif suffix in PDF_SUFFIXES:
+                text = _read_pdf_file(path)
+            else:
+                logger.info("Skipping unsupported file: %s", path)
+                continue
+        except Exception as exc:  # pragma: no cover - log and continue
+            logger.warning("Failed to read %s: %s", path, exc)
+            continue
+
+        identifier = path.relative_to(input_dir).as_posix()
+        yield Document(identifier=identifier, source=path, text=text)
+
+
+def ingest_documents(input_dir: Path, output_path: Path) -> Sequence[Document]:
+    """Ingest documents and persist the cleaned dataset."""
+
+    if not input_dir.exists():
+        raise FileNotFoundError(f"Input directory {input_dir} does not exist")
+
+    documents = list(_iter_documents(input_dir))
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as fh:
+        for doc in documents:
+            record = {
+                "id": doc.identifier,
+                "source": doc.source.as_posix(),
+                "checksum": doc.checksum,
+                "text": doc.text,
+            }
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    logger.info("Ingested %s documents into %s", len(documents), output_path)
+    return documents
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Ingest and clean documents")
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        default=Path("docs"),
+        help="Directory containing raw documents",
+    )
+    parser.add_argument(
+        "--output-path",
+        type=Path,
+        default=Path("data/processed_docs.jsonl"),
+        help="Path to write the cleaned dataset",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    args = parse_args(argv or sys.argv[1:])
+
+    try:
+        ingest_documents(args.input_dir, args.output_path)
+    except Exception as exc:
+        logger.error("Ingestion failed: %s", exc)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipelines/retrain.py
+++ b/pipelines/retrain.py
@@ -1,0 +1,179 @@
+"""Training orchestration script for the lightweight RAG example."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import statistics
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+from . import embed as embed_pipeline
+from . import ingest as ingest_pipeline
+
+logger = logging.getLogger(__name__)
+
+
+def _load_embeddings(path: Path) -> List[Dict[str, object]]:
+    if not path.exists():
+        raise FileNotFoundError(f"Embeddings not found at {path}")
+
+    embeddings: List[Dict[str, object]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            embeddings.append(json.loads(line))
+    return embeddings
+
+
+def train_model(embeddings: Iterable[Dict[str, object]]) -> Dict[str, object]:
+    """Train a trivial model on top of the embeddings.
+
+    The "model" is simply the centroid of all embedding vectors.  While simple,
+    this structure allows downstream systems to perform similarity comparisons by
+    computing the cosine similarity between a query embedding and the stored
+    centroid.
+    """
+
+    vectors = [record["embedding"] for record in embeddings]
+    if not vectors:
+        raise ValueError("No embeddings provided for training")
+
+    dim = len(vectors[0])
+    centroid = [0.0] * dim
+    for vector in vectors:
+        if len(vector) != dim:
+            raise ValueError("Embedding dimensionality mismatch detected")
+        for idx, value in enumerate(vector):
+            centroid[idx] += float(value)
+
+    centroid = [value / len(vectors) for value in centroid]
+
+    magnitudes = [sum(val * val for val in vector) ** 0.5 for vector in vectors]
+    mean_magnitude = statistics.fmean(magnitudes)
+    std_magnitude = statistics.pstdev(magnitudes)
+
+    return {
+        "centroid": centroid,
+        "embedding_dim": dim,
+        "num_vectors": len(vectors),
+        "mean_magnitude": mean_magnitude,
+        "std_magnitude": std_magnitude,
+    }
+
+
+def evaluate_model(model: Dict[str, object]) -> Dict[str, float]:
+    centroid = model["centroid"]
+    magnitude = sum(val * val for val in centroid) ** 0.5
+    return {
+        "centroid_magnitude": magnitude,
+        "embedding_dim": float(model["embedding_dim"]),
+    }
+
+
+def save_model(model: Dict[str, object], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as fh:
+        json.dump(model, fh, ensure_ascii=False, indent=2)
+
+
+def run_pipeline(
+    *,
+    run_ingest: bool,
+    run_embed: bool,
+    docs_dir: Path,
+    processed_path: Path,
+    embeddings_path: Path,
+    model_path: Path,
+    embed_dim: int,
+    recompute_embeddings: bool,
+) -> Dict[str, object]:
+    if run_ingest:
+        ingest_pipeline.ingest_documents(docs_dir, processed_path)
+
+    if run_embed:
+        embed_pipeline.embed_documents(
+            processed_path,
+            embeddings_path,
+            dim=embed_dim,
+            recompute=recompute_embeddings,
+        )
+
+    embeddings = _load_embeddings(embeddings_path)
+    model = train_model(embeddings)
+    metrics = evaluate_model(model)
+    save_model(model, model_path)
+    logger.info("Saved model to %s", model_path)
+    logger.info("Evaluation metrics: %s", metrics)
+    return metrics
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Retrain lightweight model")
+    parser.add_argument("--skip-ingest", action="store_true", help="Skip ingest stage")
+    parser.add_argument("--skip-embed", action="store_true", help="Skip embed stage")
+    parser.add_argument(
+        "--docs-dir",
+        type=Path,
+        default=Path("docs"),
+        help="Directory containing source documents",
+    )
+    parser.add_argument(
+        "--processed-path",
+        type=Path,
+        default=Path("data/processed_docs.jsonl"),
+        help="Location of cleaned documents",
+    )
+    parser.add_argument(
+        "--embeddings-path",
+        type=Path,
+        default=Path("embeddings/embeddings.jsonl"),
+        help="Embedding store location",
+    )
+    parser.add_argument(
+        "--model-path",
+        type=Path,
+        default=Path("models/model.json"),
+        help="Where to save the trained model",
+    )
+    parser.add_argument(
+        "--embed-dim",
+        type=int,
+        default=embed_pipeline.DEFAULT_EMBED_DIM,
+        help="Embedding dimensionality",
+    )
+    parser.add_argument(
+        "--recompute-embeddings",
+        action="store_true",
+        help="Regenerate embeddings even if they exist",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    args = parse_args(argv or sys.argv[1:])
+
+    try:
+        run_pipeline(
+            run_ingest=not args.skip_ingest,
+            run_embed=not args.skip_embed,
+            docs_dir=args.docs_dir,
+            processed_path=args.processed_path,
+            embeddings_path=args.embeddings_path,
+            model_path=args.model_path,
+            embed_dim=args.embed_dim,
+            recompute_embeddings=args.recompute_embeddings,
+        )
+    except Exception as exc:
+        logger.error("Retraining failed: %s", exc)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflows/auto_pipeline.n8n
+++ b/workflows/auto_pipeline.n8n
@@ -1,0 +1,57 @@
+{
+  "name": "Auto Pipeline",
+  "nodes": [
+    {
+      "parameters": {
+        "triggerTimes": [
+          {
+            "mode": "custom",
+            "cronExpression": "0 2 * * *"
+          }
+        ]
+      },
+      "id": "1",
+      "name": "Daily Schedule",
+      "type": "n8n-nodes-base.cron",
+      "typeVersion": 1,
+      "position": [
+        200,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "command": "dvc repro retrain",
+        "options": {
+          "cwd": "/workspace/tinaColab"
+        }
+      },
+      "id": "2",
+      "name": "Run DVC Pipeline",
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [
+        500,
+        300
+      ]
+    }
+  ],
+  "connections": {
+    "Daily Schedule": {
+      "main": [
+        [
+          {
+            "node": "Run DVC Pipeline",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionTimeout": 3600
+  },
+  "pinData": {},
+  "active": false
+}


### PR DESCRIPTION
## Summary
- add a document ingestion script that cleans inputs and writes JSONL outputs
- implement a deterministic embedding pipeline with incremental updates
- create a retraining orchestrator that chains ingestion and embedding before training a centroid-based model
- define DVC stages and an n8n workflow to automate the pipeline

## Testing
- python -m pipelines.ingest --input-dir docs --output-path data/processed_docs.jsonl
- python -m pipelines.embed --input-path data/processed_docs.jsonl --output-path embeddings/embeddings.jsonl
- python -m pipelines.retrain --skip-ingest --skip-embed --processed-path data/processed_docs.jsonl --embeddings-path embeddings/embeddings.jsonl --model-path models/model.json


------
https://chatgpt.com/codex/tasks/task_e_690074d109f483308e8aa010872b9e38