### PR TITLE
Add offline tests for RAG scripts and refactor for testability

### DIFF
--- a/2_1embed_store_query.py
+++ b/2_1embed_store_query.py
@@ -1,89 +1,130 @@
-"""Create a local Chroma vector store and query it.
+"""Create and populate a local Chroma vector store.
 
-This script can be run directly.  It dynamically loads the splitting logic
-from ``1_load_split.py`` so that the markdown file will be read and split into
-``advise_docs_list`` automatically.  The resulting documents are embedded and
-stored in a Chroma database.
-
-Once the embeddings are stored they can be queried again without reloading the
-data (see ``2_2getvector_query.py``).
+This module exposes utilities that ingest the markdown guidance contained in
+``data/med_instruction_v2.md`` into a persistent Chroma collection.  The
+functions are written so that they can be reused from unit tests where the
+embedding function, storage path, or client can be swapped for lightweight
+fakes.
 """
 
-import os
+from __future__ import annotations
+
 import importlib.util
+import os
+from typing import Iterable, Optional, Sequence, Tuple
+
 import chromadb
 import chromadb.utils.embedding_functions as embedding_functions
+
 import config
 
 
-def load_advise_docs():
+CollectionPayload = Tuple[Sequence[str], Sequence[dict], Sequence[str]]
+
+
+def load_advise_docs(file_path: Optional[str] = None):
     """Load and split the markdown instructions.
 
     The logic is imported from ``1_load_split.py`` so we don't duplicate the
-    splitting implementation here.
+    splitting implementation here.  A custom ``file_path`` can be supplied to
+    facilitate tests that rely on temporary fixtures.
     """
+
     module_path = os.path.join(os.path.dirname(__file__), "1_load_split.py")
     spec = importlib.util.spec_from_file_location("load_split", module_path)
     load_split = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(load_split)
 
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    file_path = os.path.join(script_dir, "data", "med_instruction_v2.md")
+    if file_path is None:
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        file_path = os.path.join(script_dir, "data", "med_instruction_v2.md")
+
     with open(file_path, "r", encoding="utf-8") as f:
         md_content = f.read()
 
     return load_split.read_split_md(md_content)
 
 
-advise_docs_list = load_advise_docs()
+def _default_openai_embedding_function():
+    return embedding_functions.OpenAIEmbeddingFunction(
+        api_key=os.environ.get("OPENAI_API_KEY"),
+        model_name="text-embedding-3-small",
+    )
 
-# 1. 用chromadb用openai api, 請先輸入自己的openai_api_key
-openai_ef_chroma = embedding_functions.OpenAIEmbeddingFunction(
-                api_key=os.environ.get('OPENAI_API_KEY'),
-                model_name="text-embedding-3-small")
 
-# 2. 用chromadb用huggingface embedding, 中文用這個不會亂碼, HF api_key自己申請
-try:
-    huggingface_api_key = config.get_huggingface_api_key()
-except RuntimeError as err:
-    raise RuntimeError(
-        "Unable to initialise the HuggingFace embedding function. "
-        f"{err}"
-    ) from err
+def _default_huggingface_embedding_function():
+    try:
+        huggingface_api_key = config.get_huggingface_api_key()
+    except RuntimeError as err:  # pragma: no cover - exercised indirectly
+        raise RuntimeError(
+            "Unable to initialise the HuggingFace embedding function. "
+            f"{err}"
+        ) from err
 
-huggingface_ef = embedding_functions.HuggingFaceEmbeddingFunction(
-    api_key=huggingface_api_key,
-    model_name="intfloat/multilingual-e5-large-instruct"
-)
+    return embedding_functions.HuggingFaceEmbeddingFunction(
+        api_key=huggingface_api_key,
+        model_name="intfloat/multilingual-e5-large-instruct",
+    )
 
-# 建本地chromaDB, name是DB的名字, 要用HF embedding就要改成huggingface_ef，目前med_vectordata2是openai_embedding
-chromadb_client = chromadb.PersistentClient(path=config.VECTOR_STORE_DIR)
-chroma_collection = chromadb_client.get_or_create_collection(name="advise_template", embedding_function=openai_ef_chroma)
 
-#傳入chromaDB 初始化空列表來儲存提取的數據
-documents = []
-metadatas = []
-ids = []
+def prepare_documents_payload(docs: Iterable) -> CollectionPayload:
+    """Transform a list of ``Document``-like objects into Chroma payloads."""
 
-# 遍歷 Document 對象列表，提取所需信息
-for index, doc in enumerate(advise_docs_list):
-    # ``Document`` objects expose their text via ``page_content``
-    documents.append(doc.page_content)
-    metadatas.append(doc.metadata)
-    ids.append(f"id{index + 1}")
+    documents = []
+    metadatas = []
+    ids = []
 
-# 現在可以將這些數據添加到 collection 中
-chroma_collection.add(
-    documents=documents,
-    metadatas=metadatas,
-    ids=ids
-)
+    for index, doc in enumerate(docs):
+        page_content = getattr(doc, "page_content", str(doc))
+        metadata = getattr(doc, "metadata", {})
+        documents.append(page_content)
+        metadatas.append(metadata)
+        ids.append(f"id{index + 1}")
 
-# 檢索querying text
-query="糖尿病前期的管理"
-results = chroma_collection.query(query_texts=[query] , n_results=3)
-retrieved_documents = results['documents'][0]
-information = "\n\n".join(retrieved_documents)
-# print(chroma_collection.get(include=["documents"]))
-print(information)
+    return documents, metadatas, ids
+
+
+def create_collection_from_docs(
+    docs: Iterable,
+    *,
+    client: Optional[chromadb.PersistentClient] = None,
+    collection_name: str = "advise_template",
+    embedding_function=None,
+    vector_store_dir: Optional[str] = None,
+):
+    """Create (or reuse) a Chroma collection and populate it with ``docs``.
+
+    Parameters are overridable to support dependency injection in tests.
+    """
+
+    if client is None:
+        client = chromadb.PersistentClient(path=vector_store_dir or config.VECTOR_STORE_DIR)
+
+    if embedding_function is None:
+        embedding_function = _default_openai_embedding_function()
+
+    collection = client.get_or_create_collection(
+        name=collection_name, embedding_function=embedding_function
+    )
+
+    documents, metadatas, ids = prepare_documents_payload(docs)
+    if documents:
+        collection.add(documents=documents, metadatas=metadatas, ids=ids)
+
+    return collection
+
+
+def main():  # pragma: no cover - thin wrapper over tested helpers
+    advise_docs_list = load_advise_docs()
+    collection = create_collection_from_docs(advise_docs_list)
+
+    query = "糖尿病前期的管理"
+    results = collection.query(query_texts=[query], n_results=3)
+    retrieved_documents = results["documents"][0]
+    information = "\n\n".join(retrieved_documents)
+    print(information)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()
 

--- a/3_1chat_LLM.py
+++ b/3_1chat_LLM.py
@@ -1,78 +1,111 @@
-# 接續2_2getvector_query.py
-# 呼叫Openai GPT4o LLM
+"""Utilities for chatting with the OpenAI model using RAG context."""
 
-import config
-from openai import OpenAI
+from __future__ import annotations
+
 import os
-import chromadb
-import chromadb.utils.embedding_functions as embedding_functions
 import pprint
 import time
+from contextlib import nullcontext
+from typing import Callable, Optional, Sequence, Union
+
+import chromadb
+import chromadb.utils.embedding_functions as embedding_functions
 import mlflow
-from mlops.mlflow_utils import start_run, log_metrics
+from openai import OpenAI
+
+import config
+from mlops.mlflow_utils import log_metrics, start_run
 
 
-# 要準備自己的system prompt, user_prompt
-GPT_MODEL = "gpt-4o" # "gpt-4-turbo-2024-04-09"or "gpt-3.5-turbo-1106" or "gpt-4o"
+GPT_MODEL = "gpt-4o"  # "gpt-4-turbo-2024-04-09"or "gpt-3.5-turbo-1106" or "gpt-4o"
 system_message = '''
-你是一位專門為醫療教育者提供量身定制建議和建議的健康教育助手，根據患者的醫療檢驗報告和病歷來提供這些建議。你的角色是使用檢索增強生成（RAG）技術來提供可能的患者問題和相關的健康教育建議。這些建議應該是清晰、專業和支持性的，並考慮到患者的具體情況和需求。
+你是一位專門為醫療教育者提供量身定制建議和建議的健康教育助手，根據患者的醫療檢驗報告和病歷來提供這些建議。你的角色是使用檢索增強
+生成（RAG）技術來提供可能的患者問題和相關的健康教育建議。這些建議應該是清晰、專業和支持性的，並考慮到患者的具體情況和需求。
 
 在製作回應時，請考慮以下要素：
 1. 患者醫療狀況的背景。
 2. 具體的醫療檢驗結果及其指示。
 3. 針對該情況的最佳健康教育實踐。
 
-確保提供準確且基於證據的建議，讓醫療教育者可以直接使用這些建議來指導患者。如果你不確定答案，你可以說「我不知道」或「我不確定」，並推薦用戶前往AAAA網站獲取更多信息。
+確保提供準確且基於證據的建議，讓醫療教育者可以直接使用這些建議來指導患者。如果你不確定答案，你可以說「我不知道」或「我不確定」，
+並推薦用戶前往AAAA網站獲取更多信息。
 輸出一定要用繁體中文輸出。
 '''
 
 user_request = '''以下是病人的病歷與檢驗報告{report}，根據提供的訊息{advise}，請提供:
 1. 衛教時可能詢問病人的問題 2.相關的衛教建議。'''
 
+
 openai_ef_chroma = embedding_functions.OpenAIEmbeddingFunction(
-                api_key=os.environ.get('OPENAI_API_KEY'),
-                model_name="text-embedding-3-small")
+    api_key=os.environ.get("OPENAI_API_KEY"), model_name="text-embedding-3-small"
+)
 chromadb_client = chromadb.PersistentClient(path=config.VECTOR_STORE_DIR)
-chroma_collection = chromadb_client.get_collection(name="advise_template", embedding_function=openai_ef_chroma)
+chroma_collection = chromadb_client.get_or_create_collection(
+    name="advise_template", embedding_function=openai_ef_chroma
+)
 
-# 這部分傳入文本要針對不同專案去設計，retrieved_documents是檢索出的資料供LLM參考，此處query是屬於哪種個案，report當作context直接放入prompt，advise是檢索出來的chunking資料, gpt4o設定seed的話可以得到比較一致的效果
-def get_chat_response(query, report, seed: int = None):
+
+def build_user_prompt(report: str, advise: str) -> str:
+    """Construct the user prompt injected into the chat payload."""
+
+    return (
+        "以下是病人的病歷與檢驗報告"
+        f"{report}，根據提供的訊息{advise}，請提供:1.衛教時可能詢問病人的問題 2.相關的衛教建議。"
+    )
+
+
+def build_messages(report: str, advise: str) -> list[dict[str, str]]:
+    return [
+        {"role": "system", "content": system_message},
+        {"role": "user", "content": build_user_prompt(report, advise)},
+    ]
+
+
+def _as_query_list(query: Union[str, Sequence[str]]) -> list[str]:
+    if isinstance(query, str):
+        return [query]
+    return list(query)
+
+
+def fetch_advise_chunks(
+    collection, query: Union[str, Sequence[str]], *, n_results: int = 2
+) -> str:
+    results = collection.query(query_texts=_as_query_list(query), n_results=n_results)
+    retrieved_documents = results["documents"][0]
+    return "\n\n".join(retrieved_documents)
+
+
+def get_chat_response(
+    query: Union[str, Sequence[str]],
+    report: str,
+    *,
+    seed: Optional[int] = None,
+    collection=None,
+    client: Optional[OpenAI] = None,
+    run_context_factory: Optional[Callable[[], object]] = None,
+) -> Optional[str]:
     try:
-        results = chroma_collection.query(query_texts=query , n_results=2)
-        retrieved_documents = results['documents'][0]
-        advise = "\n\n".join(retrieved_documents)
-        
-        messages = [
-            {"role": "system", "content": system_message},
-            {"role": "user", "content": f"以下是病人的病歷與檢驗報告{report}，根據提供的訊息{advise}，請提供:1.衛教時可能詢問病人的問題 2.相關的衛教建議。"},
-        ]
+        target_collection = collection or chroma_collection
+        advise = fetch_advise_chunks(target_collection, query, n_results=2)
+        messages = build_messages(report, advise)
 
-
-        client = OpenAI(
-            # This is the default and can be omitted
-            api_key=os.environ.get('OPENAI_API_KEY'),
-        )
+        openai_client = client or OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
         start = time.time()
-        completion = client.chat.completions.create(
+        completion = openai_client.chat.completions.create(
             model=GPT_MODEL,
             messages=messages,
             seed=seed,
             max_tokens=2000,
             temperature=0.7,
-
         )
 
         response_content = completion.choices[0].message.content
         duration_sec = time.time() - start
-        # print(f"response content: {response_content}")
         system_fingerprint = completion.system_fingerprint
-        # print(f"system_fingerprint: {system_fingerprint}")
-        prompt_tokens = completion.usage.prompt_tokens #response["usage"]["prompt_tokens"]
-        completion_tokens = (
-            completion.usage.total_tokens - prompt_tokens
-        )
-        
+        prompt_tokens = completion.usage.prompt_tokens
+        completion_tokens = completion.usage.total_tokens - prompt_tokens
+
         tokens = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
@@ -89,28 +122,41 @@ def get_chat_response(query, report, seed: int = None):
             "vectordata": "med_vectordata2",
         }
 
-        # 使用 pprint 來漂亮列印資料
         pp = pprint.PrettyPrinter(indent=4)
         pp.pprint(output_data)
 
-        with start_run("openai_chat"):
+        context_factory = run_context_factory or (lambda: start_run("openai_chat"))
+        context = context_factory()
+        if context is None:
+            context = nullcontext()
+        with context:
             mlflow.log_text(response_content, "response.txt")
-            log_metrics(tokens=tokens, durations=durations, model_name=GPT_MODEL, prompt=messages[-1]["content"])
+            log_metrics(
+                tokens=tokens,
+                durations=durations,
+                model_name=GPT_MODEL,
+                prompt=messages[-1]["content"],
+            )
 
         return response_content
-        
-    except Exception as e:
+
+    except Exception as e:  # pragma: no cover - defensive fallback
         print(f"An error occurred: {e}")
         return None
 
-#testing
-query="糖尿病前期"
-try:
-    with open(config.PATIENT_FILE, "r") as f:
-        p_testing_report = f.read()
-except FileNotFoundError:
-    print(f"{config.PATIENT_FILE} not found, using empty report")
-    p_testing_report = ""
 
-p_c = get_chat_response(query, p_testing_report)
-print(p_c)
+def main():  # pragma: no cover - thin wrapper around the tested helper
+    query = "糖尿病前期"
+    try:
+        with open(config.PATIENT_FILE, "r") as f:
+            p_testing_report = f.read()
+    except FileNotFoundError:
+        print(f"{config.PATIENT_FILE} not found, using empty report")
+        p_testing_report = ""
+
+    response = get_chat_response(query, p_testing_report)
+    print(response)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/3_2chat_LLM_local.py
+++ b/3_2chat_LLM_local.py
@@ -1,66 +1,108 @@
-# 接續2_getvector_query.py
-# 呼叫local LLM
-import config
-import requests
-import chromadb
-import chromadb.utils.embedding_functions as embedding_functions
+"""Interact with a locally hosted LLM using retrieved context."""
+
+from __future__ import annotations
+
 import os
 import pprint
+from contextlib import nullcontext
+from typing import Callable, Optional, Sequence, Union
+
+import chromadb
+import chromadb.utils.embedding_functions as embedding_functions
 import mlflow
-from mlops.mlflow_utils import start_run, log_metrics
+import requests
+
+import config
+from mlops.mlflow_utils import log_metrics, start_run
+
 
 openai_ef_chroma = embedding_functions.OpenAIEmbeddingFunction(
-                api_key=os.environ.get('OPENAI_API_KEY'),
-                model_name="text-embedding-3-small")
+    api_key=os.environ.get("OPENAI_API_KEY"), model_name="text-embedding-3-small"
+)
 chromadb_client = chromadb.PersistentClient(path=config.VECTOR_STORE_DIR)
-chroma_collection = chromadb_client.get_collection(name="advise_template", embedding_function=openai_ef_chroma)
+chroma_collection = chromadb_client.get_or_create_collection(
+    name="advise_template", embedding_function=openai_ef_chroma
+)
 
 system_message = '''
-你是一位專門為醫療教育者提供量身定制建議和建議的健康教育助手，根據患者的醫療檢驗報告和病歷來提供這些建議。你的角色是使用檢索增強生成（RAG）技術來提供可能的患者問題和相關的健康教育建議。這些建議應該是清晰、專業和支持性的，並考慮到患者的具體情況和需求。
+你是一位專門為醫療教育者提供量身定制建議和建議的健康教育助手，根據患者的醫療檢驗報告和病歷來提供這些建議。你的角色是使用檢索增強
+生成（RAG）技術來提供可能的患者問題和相關的健康教育建議。這些建議應該是清晰、專業和支持性的，並考慮到患者的具體情況和需求。
 
 在製作回應時，請考慮以下要素：
 1. 患者醫療狀況的背景。
 2. 具體的醫療檢驗結果及其指示。
 3. 針對該情況的最佳健康教育實踐。
 
-確保提供準確且基於證據的建議，讓醫療教育者可以直接使用這些建議來指導患者。如果你不確定答案，你可以說「我不知道」或「我不確定」，並推薦用戶前往XXXX網站獲取更多信息。
+確保提供準確且基於證據的建議，讓醫療教育者可以直接使用這些建議來指導患者。如果你不確定答案，你可以說「我不知道」或「我不確定」，
+並推薦用戶前往XXXX網站獲取更多信息。
 輸出一定要用繁體中文輸出。
 '''
 user_request = '''以下是病人的病歷與檢驗報告{report}，根據提供的訊息{advise}，請提供:
 1. 衛教時可能詢問病人的問題 2.相關的衛教建議。'''
 
-# 模型可參考ollama list裡面的模型
-def get_ollama_chat_response(query, report, model=config.DEFAULT_LOCAL_MODEL):
+
+def build_user_prompt(report: str, advise: str) -> str:
+    return (
+        "以下是病人的病歷與檢驗報告"
+        f"{report}，根據提供的訊息{advise}，請提供:1.衛教時可能詢問病人的問題 2.相關的衛教建議。"
+    )
+
+
+def build_messages(report: str, advise: str) -> list[dict[str, str]]:
+    return [
+        {"role": "system", "content": system_message},
+        {"role": "user", "content": build_user_prompt(report, advise)},
+    ]
+
+
+def _as_query_list(query: Union[str, Sequence[str]]) -> list[str]:
+    if isinstance(query, str):
+        return [query]
+    return list(query)
+
+
+def fetch_advise_chunks(
+    collection, query: Union[str, Sequence[str]], *, n_results: int = 5
+) -> str:
+    results = collection.query(query_texts=_as_query_list(query), n_results=n_results)
+    retrieved_documents = results["documents"][0]
+    return "\n\n".join(retrieved_documents)
+
+
+def get_ollama_chat_response(
+    query: Union[str, Sequence[str]],
+    report: str,
+    *,
+    model: str = config.DEFAULT_LOCAL_MODEL,
+    collection=None,
+    requester: Optional[Callable[..., requests.Response]] = None,
+    run_context_factory: Optional[Callable[[], object]] = None,
+):
     try:
-        results = chroma_collection.query(query_texts=[query], n_results=5)
-        retrieved_documents = results['documents'][0]
-        advise = "\n\n".join(retrieved_documents)
-        
+        target_collection = collection or chroma_collection
+        advise = fetch_advise_chunks(target_collection, query, n_results=5)
+        messages = build_messages(report, advise)
+
         url = "http://localhost:11434/api/chat"
         data = {
             "model": model,
-            "messages": [
-                {'role': 'system', 'content': system_message},
-                {'role': 'user', 'content': f"以下是病人的病歷與檢驗報告{report}，根據提供的訊息{advise}，請提供:1.衛教時可能詢問病人的問題 2.相關的衛教建議。"},
-            ],
+            "messages": messages,
             "stream": False,
         }
-        
-        response = requests.post(url, json=data)
-        response.raise_for_status()  # 確保請求成功，否則引發 HTTPError
 
-        # 處理回應
+        post = requester or requests.post
+        response = post(url, json=data)
+        response.raise_for_status()
+
         completion = response.json()
-        response_content = completion['message']['content']
-        prompt_tokens = completion['prompt_eval_count']
-        completion_tokens = completion['eval_count'] 
-        
-        
-        # 將奈秒轉換微秒
-        total_duration_sec = completion['total_duration'] / 1e9
-        load_duration_sec = completion['load_duration'] / 1e9
-        prompt_eval_duration_sec = completion['prompt_eval_duration'] / 1e9
-        gen_eval_duration_sec = completion['eval_duration'] / 1e9
+        response_content = completion["message"]["content"]
+        prompt_tokens = completion["prompt_eval_count"]
+        completion_tokens = completion["eval_count"]
+
+        total_duration_sec = completion["total_duration"] / 1e9
+        load_duration_sec = completion["load_duration"] / 1e9
+        prompt_eval_duration_sec = completion["prompt_eval_duration"] / 1e9
+        gen_eval_duration_sec = completion["eval_duration"] / 1e9
 
         tokens = {
             "prompt_tokens": prompt_tokens,
@@ -79,30 +121,43 @@ def get_ollama_chat_response(query, report, model=config.DEFAULT_LOCAL_MODEL):
             "Response": response_content,
             **tokens,
             **durations,
-            "vectordata": "med_vectordata2"
+            "vectordata": "med_vectordata2",
         }
 
-        # 使用 pprint 來漂亮列印資料
         pp = pprint.PrettyPrinter(indent=4)
         pp.pprint(output_data)
 
-        with start_run("local_llm"):
+        context_factory = run_context_factory or (lambda: start_run("local_llm"))
+        context = context_factory()
+        if context is None:
+            context = nullcontext()
+        with context:
             mlflow.log_text(response_content, "response.txt")
-            log_metrics(tokens=tokens, durations=durations, model_name=model, prompt=data["messages"][1]["content"])
+            log_metrics(
+                tokens=tokens,
+                durations=durations,
+                model_name=model,
+                prompt=messages[-1]["content"],
+            )
 
         return response_content
-    
-    except requests.exceptions.RequestException as e:
+
+    except requests.exceptions.RequestException as e:  # pragma: no cover - network handling
         return f'網路請求錯誤: {e}'
-    except KeyError as e:
-        return '回應中沒有預期的數據結構: {e}'
-    except Exception as e:
+    except KeyError as e:  # pragma: no cover - unexpected response handling
+        return f'回應中沒有預期的數據結構: {e}'
+    except Exception as e:  # pragma: no cover - defensive fallback
         return f'未知錯誤: {e}'
 
-#testing
-query="糖尿病前期"
-with open(config.PATIENT_FILE,'r') as f:
-    p_testing_report = f.read()
 
-p_c = get_ollama_chat_response(query, p_testing_report)
-print(p_c)
+def main():  # pragma: no cover - thin wrapper for manual execution
+    query = "糖尿病前期"
+    with open(config.PATIENT_FILE, 'r') as f:
+        p_testing_report = f.read()
+
+    response = get_ollama_chat_response(query, p_testing_report)
+    print(response)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ python rag_example.py
 ```
 Demonstrates loading a PDF, chunking it, storing embeddings and then querying via a local LLM.
 
+## Testing
+
+Offline unit tests cover the document ingestion, vector querying and prompt assembly flows used throughout the RAG examples. Run
+them whenever you modify the pipeline to ensure regressions are caught early:
+
+```bash
+pytest tests/test_rag_data_scripts.py tests/test_rag_chat_scripts.py
+```
+
+The tests rely on in-memory fakes and mocked API clients so they do not require network access or actual API keys beyond dummy
+values supplied via the test harness.
+
 ## MLflow Tracking
 
 To record experiment results with MLflow, set the `MLFLOW_TRACKING_URI` environment variable to your tracking server or a local directory. Once set, metrics and parameters can be logged from within the scripts using the `mlflow` Python API (not enabled by default in these examples).

--- a/tests/test_rag_chat_scripts.py
+++ b/tests/test_rag_chat_scripts.py
@@ -1,0 +1,154 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_module(name: str, relative_path: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / relative_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def chat_module(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    module = load_module("chat_llm_script", "3_1chat_LLM.py")
+    monkeypatch.setattr(module, "log_metrics", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module.mlflow, "log_text", lambda *args, **kwargs: None)
+    return module
+
+
+@pytest.fixture()
+def local_chat_module(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    module = load_module("chat_llm_local_script", "3_2chat_LLM_local.py")
+    monkeypatch.setattr(module, "log_metrics", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module.mlflow, "log_text", lambda *args, **kwargs: None)
+    return module
+
+
+class StubCollection:
+    def __init__(self, documents):
+        self.documents = documents
+        self.queries = []
+
+    def query(self, *, query_texts, n_results):
+        self.queries.append((query_texts, n_results))
+        return {"documents": [self.documents[:n_results]]}
+
+
+class StubChatCompletions:
+    def __init__(self, response_text):
+        self.response_text = response_text
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        usage = SimpleNamespace(prompt_tokens=5, total_tokens=9)
+        choice = SimpleNamespace(message=SimpleNamespace(content=self.response_text))
+        return SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+            system_fingerprint="fingerprint",
+        )
+
+
+class StubOpenAIClient:
+    def __init__(self, response_text):
+        self.chat = SimpleNamespace(completions=StubChatCompletions(response_text))
+
+
+class StubResponse:
+    def __init__(self, payload):
+        self._payload = payload
+        self.raise_calls = []
+
+    def raise_for_status(self):
+        self.raise_calls.append(True)
+
+    def json(self):
+        return self._payload
+
+
+class StubRequester:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = []
+
+    def __call__(self, url, json):
+        self.calls.append((url, json))
+        return StubResponse(self.payload)
+
+
+class NoOpContext:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+
+@pytest.fixture()
+def run_context_factory():
+    return lambda: NoOpContext()
+
+
+def test_build_user_prompt_contains_context(chat_module):
+    prompt = chat_module.build_user_prompt("報告內容", "建議內容")
+    assert "報告內容" in prompt
+    assert "建議內容" in prompt
+
+
+def test_get_chat_response_assembles_messages(chat_module, run_context_factory):
+    collection = StubCollection(["建議一", "建議二"])
+    client = StubOpenAIClient("最終回應")
+
+    response = chat_module.get_chat_response(
+        "糖尿病前期",
+        "病歷描述",
+        collection=collection,
+        client=client,
+        run_context_factory=run_context_factory,
+    )
+
+    assert response == "最終回應"
+    assert collection.queries[0][0] == ["糖尿病前期"]
+    messages = client.chat.completions.calls[0]["messages"]
+    assert messages[0]["role"] == "system"
+    assert "病歷描述" in messages[1]["content"]
+
+
+def test_get_ollama_chat_response_builds_payload(local_chat_module, run_context_factory):
+    collection = StubCollection(["建議一", "建議二"])
+    payload = {
+        "message": {"content": "本地回應"},
+        "prompt_eval_count": 7,
+        "eval_count": 11,
+        "total_duration": 1_000_000_000,
+        "load_duration": 200_000_000,
+        "prompt_eval_duration": 300_000_000,
+        "eval_duration": 400_000_000,
+    }
+    requester = StubRequester(payload)
+
+    response = local_chat_module.get_ollama_chat_response(
+        "糖尿病前期",
+        "病歷描述",
+        collection=collection,
+        requester=requester,
+        run_context_factory=run_context_factory,
+        model="demo-model",
+    )
+
+    assert response == "本地回應"
+    url, data = requester.calls[0]
+    assert url == "http://localhost:11434/api/chat"
+    assert data["model"] == "demo-model"
+    assert data["messages"][0]["role"] == "system"
+    assert "病歷描述" in data["messages"][1]["content"]

--- a/tests/test_rag_data_scripts.py
+++ b/tests/test_rag_data_scripts.py
@@ -1,0 +1,133 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_module(name: str, relative_path: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / relative_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeEmbeddingFunction:
+    def __call__(self, input):
+        if isinstance(input, str):
+            texts = [input]
+        else:
+            texts = list(input)
+        embeddings = []
+        for text in texts:
+            score = float(sum(ord(char) for char in text) % 97)
+            embeddings.append([score, score / 2, score / 3])
+        return embeddings
+
+    def name(self):
+        return "fake"
+
+    def is_legacy(self):
+        return False
+
+
+@pytest.fixture()
+def embed_module(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    return load_module("embed_store_script", "2_1embed_store_query.py")
+
+
+@pytest.fixture()
+def query_module(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    return load_module("query_store_script", "2_2getvector_query.py")
+
+
+@pytest.fixture()
+def fake_docs():
+    return [
+        SimpleNamespace(
+            page_content="糖尿病前期的管理",
+            metadata={"source": "doc1"},
+        ),
+        SimpleNamespace(
+            page_content="高血壓飲食建議",
+            metadata={"source": "doc2"},
+        ),
+    ]
+
+
+@pytest.fixture()
+def fake_embedding():
+    return FakeEmbeddingFunction()
+
+
+class FakeCollection:
+    def __init__(self):
+        self.documents = []
+        self.metadatas = []
+        self.ids = []
+
+    def add(self, *, documents, metadatas, ids):
+        self.documents.extend(documents)
+        self.metadatas.extend(metadatas)
+        self.ids.extend(ids)
+
+    def get(self, include):
+        result = {}
+        for item in include:
+            if item == "documents":
+                result[item] = list(self.documents)
+            elif item == "metadatas":
+                result[item] = list(self.metadatas)
+            elif item == "ids":
+                result[item] = list(self.ids)
+        return result
+
+    def query(self, *, query_texts, n_results):
+        return {"documents": [self.documents[:n_results]]}
+
+
+class FakeClient:
+    def __init__(self):
+        self.collections = {}
+
+    def get_or_create_collection(self, name, embedding_function):
+        if name not in self.collections:
+            self.collections[name] = FakeCollection()
+        return self.collections[name]
+
+
+def test_create_collection_from_docs(embed_module, fake_docs, fake_embedding):
+    client = FakeClient()
+    collection = embed_module.create_collection_from_docs(
+        fake_docs,
+        client=client,
+        collection_name="test_collection",
+        embedding_function=fake_embedding,
+    )
+
+    stored = collection.get(include=["documents", "metadatas", "ids"])
+    assert stored["documents"] == [doc.page_content for doc in fake_docs]
+    assert stored["metadatas"] == [doc.metadata for doc in fake_docs]
+    assert stored["ids"] == [f"id{i + 1}" for i in range(len(fake_docs))]
+
+
+def test_query_collection_returns_expected_payload(
+    embed_module, query_module, fake_docs, fake_embedding
+):
+    client = FakeClient()
+    collection = embed_module.create_collection_from_docs(
+        fake_docs,
+        client=client,
+        collection_name="test_collection",
+        embedding_function=fake_embedding,
+    )
+
+    information = query_module.query_collection(
+        collection, "糖尿病前期的管理", n_results=1
+    )
+
+    assert fake_docs[0].page_content in information


### PR DESCRIPTION
## Summary
- refactor the embed/store and query scripts to expose reusable helpers and guard script entry points
- add dependency-injection hooks to the OpenAI and local chat scripts to enable mocking in unit tests
- create offline pytest suites covering the data ingestion, vector querying, and chat prompt assembly flows
- document how to run the new tests in the project README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69007697af5c8330a50b482fa76a9196